### PR TITLE
Use IStyleable to fix the Slider not showing on screen

### DIFF
--- a/src/Fabulous.Avalonia/Views/Controls/Slider.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Slider.fs
@@ -1,9 +1,13 @@
 namespace Fabulous.Avalonia
 
 open System
+open System.Runtime.CompilerServices
 open Avalonia
+open Avalonia.Collections
 open Avalonia.Controls
 open Avalonia.Controls.Primitives
+open Avalonia.Layout
+open Avalonia.Styling
 open Fabulous
 
 type IFabSlider = inherit IFabRangeBase
@@ -19,9 +23,41 @@ type FabSlider() =
     override this.OnPropertyChanged(args: AvaloniaPropertyChangedEventArgs) =
         if args.Property = RangeBase.ValueProperty then
             _valueChanged.Trigger(this, RangeBaseValueChangedEventArgs(args.OldValue :?> float, args.NewValue :?> float))
+            
+    interface IStyleable with
+            member this.StyleKey = typeof<Slider>
 
 module Slider =
     let WidgetKey = Widgets.register<FabSlider>()
+    
+    let Orientation =
+        Attributes.defineAvaloniaPropertyWithEquality Slider.OrientationProperty
+        
+    let IsDirectionReversed =
+        Attributes.defineAvaloniaPropertyWithEquality Slider.IsDirectionReversedProperty
+        
+    let IsSnapToTickEnabled =
+        Attributes.defineAvaloniaPropertyWithEquality Slider.IsSnapToTickEnabledProperty
+        
+    let TickFrequency =
+        Attributes.defineAvaloniaPropertyWithEquality Slider.TickFrequencyProperty
+        
+    let TickPlacement =
+        Attributes.defineAvaloniaPropertyWithEquality Slider.TickPlacementProperty
+        
+    let Ticks =
+        Attributes.defineSimpleScalarWithEquality<float list>
+            "Slider_Ticks"
+            (fun _ newValueOpt node ->
+                let target = node.Target :?> AvaloniaObject
+
+                match newValueOpt with
+                | ValueNone -> target.ClearValue(Slider.TicksProperty)
+                | ValueSome points ->
+                    let coll = AvaloniaList<float>()
+                    points |> List.iter coll.Add
+                    target.SetValue(Slider.TicksProperty, coll) |> ignore)
+    
     let ValueChanged = Attributes.defineEvent "Slider_ValueChanged" (fun target -> (target :?> FabSlider).ValueChanged)
     
 [<AutoOpen>]
@@ -34,3 +70,29 @@ module SliderBuilders =
                 RangeBase.Value.WithValue(value),
                 Slider.ValueChanged.WithValue(fun args -> onValueChanged args.NewValue |> box)
             )
+            
+[<Extension>]
+type SliderModifiers =
+    [<Extension>]
+    static member inline orientation(this: WidgetBuilder<'msg, #IFabSlider>, value: Orientation) =
+        this.AddScalar(Slider.Orientation.WithValue(value))
+        
+    [<Extension>]
+    static member inline isDirectionReversed(this: WidgetBuilder<'msg, #IFabSlider>, value: bool) =
+        this.AddScalar(Slider.IsDirectionReversed.WithValue(value))
+        
+    [<Extension>]
+    static member inline isSnapToTickEnabled(this: WidgetBuilder<'msg, #IFabSlider>, value: bool) =
+        this.AddScalar(Slider.IsSnapToTickEnabled.WithValue(value))
+        
+    [<Extension>]
+    static member inline tickFrequency(this: WidgetBuilder<'msg, #IFabSlider>, value: float) =
+        this.AddScalar(Slider.TickFrequency.WithValue(value))
+        
+    [<Extension>]
+    static member inline tickPlacement(this: WidgetBuilder<'msg, #IFabSlider>, value: TickPlacement) =
+        this.AddScalar(Slider.TickPlacement.WithValue(value))
+        
+    [<Extension>]
+    static member inline ticks(this: WidgetBuilder<'msg, #IFabSlider>, value: float list) =
+        this.AddScalar(Slider.Ticks.WithValue(value))

--- a/src/Fabulous.Avalonia/Views/Controls/_RangeBase.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/_RangeBase.fs
@@ -1,6 +1,7 @@
 namespace Fabulous.Avalonia
 
 open System
+open System.Runtime.CompilerServices
 open Avalonia.Controls.Primitives
 open Fabulous
 
@@ -35,4 +36,19 @@ module RangeBase =
         Attributes.defineSimpleScalarWithEquality<struct (float * float)>
             "RangeBase_MinimumMaximum"
             RangeBaseUpdaters.updateSliderMinMax
+    
     let Value = Attributes.defineAvaloniaPropertyWithEquality RangeBase.ValueProperty
+    
+    let SmallChange = Attributes.defineAvaloniaPropertyWithEquality RangeBase.SmallChangeProperty
+    
+    let LargeChange = Attributes.defineAvaloniaPropertyWithEquality RangeBase.LargeChangeProperty
+
+[<Extension>]
+type RangeBaserModifiers =
+    [<Extension>]
+    static member inline smallChange(this: WidgetBuilder<'msg, #IFabRangeBase>, value: float) =
+        this.AddScalar(RangeBase.SmallChange.WithValue(value))
+
+    [<Extension>]
+    static member inline largeChange(this: WidgetBuilder<'msg, #IFabRangeBase>, value: float) =
+        this.AddScalar(RangeBase.LargeChange.WithValue(value))


### PR DESCRIPTION
Seems like when you extend any control in Avalonia you need to use 

```fsharp
interface IStyleable with
     member this.StyleKey = typeof<Slider>
```

So the control can use its specific style 

https://user-images.githubusercontent.com/31915729/202919137-5bbf75bb-d5bd-40fc-b786-429f159d9eaf.mp4


